### PR TITLE
ponytail: cut over-engineering

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,18 +8,15 @@ on:
 
 jobs:
   ci:
-    name: CI (Node ${{ matrix.node }})
+    name: CI
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        node: [20, 22]
 
     steps:
       - uses: actions/checkout@v4
 
       - uses: actions/setup-node@v4
         with:
-          node-version: ${{ matrix.node }}
+          node-version: 20
           cache: npm
 
       - name: Install

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,8 +24,8 @@ All notable changes to this project will be documented in this file.
 - **Viewport collision** now uses `IntersectionObserver` (zero-cost, edge-triggered) instead of rAF polling. Fires immediately on mount when the element is already visible.
 - **Element-element group collision** retains rAF + AABB for arbitrary element pair checks (IntersectionObserver cannot cover this).
 - **TypeScript** — fully typed source with `.d.ts` declarations shipped in `dist/`.
-- **Vite library mode build** — ships ESM (`dist/vue-collision.js`) + UMD CJS (`dist/vue-collision.umd.cjs`) with proper `exports` map and `types` field.
-- **CI** — GitHub Actions on Node 20 and 22 (install → typecheck → build → test).
+- **Vite library mode build** — ships ESM (`dist/vue-collision.js`) + CJS (`dist/vue-collision.cjs`) with proper `exports` map and `types` field.
+- **CI** — GitHub Actions on Node 20 LTS (install → typecheck → build → test).
 
 ### Bug fixes (inherited from 1.6.0 source)
 

--- a/package.json
+++ b/package.json
@@ -21,14 +21,14 @@
     "directive",
     "bounding-box"
   ],
-  "main": "./dist/vue-collision.umd.cjs",
+  "main": "./dist/vue-collision.cjs",
   "module": "./dist/vue-collision.js",
   "types": "./dist/index.d.ts",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",
       "import": "./dist/vue-collision.js",
-      "require": "./dist/vue-collision.umd.cjs"
+      "require": "./dist/vue-collision.cjs"
     }
   },
   "files": [

--- a/src/index.ts
+++ b/src/index.ts
@@ -227,8 +227,3 @@ export default VueCollision
 // Convenience re-exports for tree-shaking and testing
 // ---------------------------------------------------------------------------
 export { directive as collisionDirective }
-
-// In-browser CDN auto-install
-if (typeof window !== 'undefined' && 'Vue' in window) {
-  ;(window as unknown as Record<string, { use: (p: Plugin) => void }>)['Vue'].use(VueCollision)
-}

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -18,17 +18,13 @@ export default defineConfig({
   build: {
     lib: {
       entry: resolve(__dirname, 'src/index.ts'),
-      name: 'VueCollision',
-      formats: ['es', 'umd'],
-      fileName: (format) => `vue-collision.${format === 'es' ? 'js' : 'umd.cjs'}`,
+      formats: ['es', 'cjs'],
+      fileName: (format) => `vue-collision.${format === 'es' ? 'js' : 'cjs'}`,
     },
     rollupOptions: {
       external: ['vue'],
       output: {
         exports: 'named',
-        globals: {
-          vue: 'Vue',
-        },
       },
     },
   },


### PR DESCRIPTION
## What was cut

| Cut | Category | Before → After |
|-----|----------|----------------|
| UMD build format | build | `['es', 'umd']` → `['es', 'cjs']`; removes `name`, `globals`, renames output from `.umd.cjs` → `.cjs` |
| CDN auto-install block | src | 4 lines at bottom of `src/index.ts` (`'Vue' in window` IIFE) — UMD-only pattern, dead code once UMD is gone |
| CI node matrix `[20, 22]` | CI | Single Node 20 LTS; halves CI runtime with zero coverage loss for a library that targets bundlers |

**Net diff: -12 lines across 5 files.**

## What was kept (with reason)

- **ESLint/Prettier** — not present; already cut by the repo.
- **husky/lint-staged/commitlint/release-it** — not present; already cut by the repo.
- **Multiple tsconfigs** — only one exists; nothing to collapse.
- **`collisionDirective` re-export** — public API surface; external consumers may import it.
- **`checkCollision`/`combine` exports** — tested directly; public surface.
- **All exported types** (`Rect`, `CollisionGroupState`, `CollisionOptions`) — public API surface.
- **`VueCollision` plugin** — does real work (config injection of `globalTriggers`, global listener setup).
- **CJS `require` interop** — UMD dropped but CJS kept; non-breaking for Node consumers.

## Gate

```
npm ci && npm run build && npm test && npm run typecheck
```

All green on Node 22.22.3 (local; CI will use Node 20):
- build: `dist/vue-collision.js` (ESM, 2.71 kB) + `dist/vue-collision.cjs` (CJS, 2.20 kB)
- test: 19/19 passed
- typecheck: clean

https://claude.ai/code/session_01NXBkkU4ArQJH2CASi3VmhC